### PR TITLE
Bug 229 When you click on logo its scroll to top

### DIFF
--- a/src/containers/layout/navbar/NavBar.tsx
+++ b/src/containers/layout/navbar/NavBar.tsx
@@ -102,10 +102,10 @@ const Navbar = () => {
   return (
     <Box sx={styles.header}>
       <Button
-        component={Link}
+        component={HashLink}
         size={SizeEnum.Small}
         sx={styles.logoButton}
-        to={guestRoutes.home.path}
+        to={guestRoutes.welcome.path}
       >
         <Logo />
       </Button>


### PR DESCRIPTION
when you are somewhere at the bottom of the page you can click on the logo and get to the very beginning of the site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Navigation Updates**
	- Modified navbar button to use a different link type
	- Updated navigation destination within the app's routing system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->