### PR TITLE
Added chips to Subjects step

### DIFF
--- a/src/components/app-chips-list/AppChipsList-styles.ts
+++ b/src/components/app-chips-list/AppChipsList-styles.ts
@@ -22,6 +22,7 @@ export const styles = {
     color: 'primary.700',
     typography: 'subtitle2',
     borderRadius: '10px',
+    letterSpacing: '0.25%',
     height: 'fit-content',
     '& .MuiChip-label': {
       p: '7px 14px',

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -1,7 +1,7 @@
 {
   "stepLabels": {
-    "generalInfo": "Загальне", 
-    "language": "Мова", 
+    "generalInfo": "Загальне",
+    "language": "Мова",
     "subjects": "Предмети",
     "photo": "Фото"
   },
@@ -19,7 +19,7 @@
     "autocompleteLabel": "Твоя рідна мова"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Будь ласка, виберіть основні предмети на основі категорії. Ви можете додати інші пізніше.",
     "mainSubjectsLabel": "Основна категорія предмету",
     "subjectLabel": "Предмет",
     "btnText": "Додайте ще один предмет",

--- a/src/containers/tutor-home-page/subjects-step/constants.js
+++ b/src/containers/tutor-home-page/subjects-step/constants.js
@@ -8,8 +8,8 @@ export const categoriesMock = [
 
 export const subjectsMock = [
   {
-    name: 'mathematics',
-    values: [
+    category: 'Mathematics',
+    subjects: [
       { name: 'Logic' },
       { name: 'Geometry' },
       { name: 'Algebra' },
@@ -17,8 +17,8 @@ export const subjectsMock = [
     ]
   },
   {
-    name: 'languages',
-    values: [
+    category: 'Languages',
+    subjects: [
       { name: 'English' },
       { name: 'Ukraine' },
       { name: 'Chinese' },
@@ -26,8 +26,8 @@ export const subjectsMock = [
     ]
   },
   {
-    name: 'music',
-    values: [
+    category: 'Music',
+    subjects: [
       { name: 'Vocal' },
       { name: 'Piano' },
       { name: 'Guitar' },
@@ -35,8 +35,8 @@ export const subjectsMock = [
     ]
   },
   {
-    name: 'computer science',
-    values: [
+    category: 'Computer science',
+    subjects: [
       { name: 'FrontEnd (React)' },
       { name: 'Backend (Node.js)' },
       { name: 'SQL' },
@@ -44,8 +44,8 @@ export const subjectsMock = [
     ]
   },
   {
-    name: 'history',
-    values: [
+    category: 'History',
+    subjects: [
       { name: 'European and world history' },
       { name: 'Greek history' },
       { name: 'History of the British Isles' },

--- a/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.jsx
+++ b/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.jsx
@@ -1,76 +1,114 @@
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useState } from 'react'
 
 import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
 
 import { styles } from './SubjectForm.styles'
 
 import AppSelect from '~/components/app-select/AppSelect'
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
 import AppButton from '~/components/app-button/AppButton'
+import AppChipList from '~/components/app-chips-list/AppChipList'
 
-import {
-  categoriesMock,
-  subjectsMock
-} from '~/containers/tutor-home-page/subjects-step/constants.js'
+import { useStepContext } from '~/context/step-context'
+import { subjectsMock } from '~/containers/tutor-home-page/subjects-step/constants.js'
 
 const SubjectForm = ({ handleSubmit }) => {
-  const [searchCategory, setSearchCategory] = useState('')
-  const [searchSubject, setSearchSubject] = useState('')
-  const [inputCategory, setInputCategory] = useState('')
-
+  const { stepData } = useStepContext()
   const { t } = useTranslation()
 
-  const categories = (value = []) =>
-    value.map(({ name }) => {
-      return {
-        title: name,
-        value: name.toLocaleLowerCase()
-      }
-    })
+  const [inputCategory, setInputCategory] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedSubject, setSelectedSubject] = useState('')
+  const [subjectsChipList, setSubjectsChipList] = useState([
+    ...stepData.subjects
+  ])
+
+  useEffect(() => {
+    stepData.subjects = subjectsChipList
+  }, [subjectsChipList, stepData])
 
   const getCategoryArray = (value = []) => {
     const newCatArr = []
-    value.map(({ name }) => newCatArr.push(name))
+    value.map(({ category }) => newCatArr.push(category))
 
     return newCatArr
   }
 
-  const subjects = subjectsMock.find(
-    (item) => item.name === searchCategory.toLocaleLowerCase()
+  const getCategorySubjects = subjectsMock.find(
+    ({ category }) =>
+      category.toLowerCase() === selectedCategory.toLocaleLowerCase()
   )
 
-  const onInputChange = (_, value) => setInputCategory(value)
+  const subjectFields = (value = []) =>
+    value.map(({ name }) => {
+      return {
+        title: name,
+        value: name
+      }
+    })
 
-  const handleAutoCompleteChange = (_, value) => {
-    value ? setSearchCategory(value) : setSearchCategory('')
+  const onInputChangeCategory = (_, value) => setInputCategory(value)
+
+  const handleAutoCompleteChangeCategory = (_, value) => {
+    value ? setSelectedCategory(value) : setSelectedCategory('')
   }
 
-  const handleChangeSubject = (event) => setSearchSubject(event)
+  const handleSelectSubject = (event) => {
+    setSelectedSubject(event)
+  }
+
+  const handleDelete = (chipToDelete) => {
+    const filteredSubject = subjectsChipList.filter(
+      (chip) => chip !== chipToDelete
+    )
+    setSubjectsChipList(() => filteredSubject)
+  }
+
+  const addCategory = () => {
+    if (selectedSubject) {
+      if (!subjectsChipList.includes(selectedSubject)) {
+        setSubjectsChipList(() => [...subjectsChipList, selectedSubject])
+      }
+      setSelectedCategory('')
+      setSelectedSubject('')
+    }
+  }
 
   return (
     <Box component='form' onSubmit={handleSubmit} sx={styles.form}>
       <AppAutoComplete
         inputValue={inputCategory}
-        onChange={handleAutoCompleteChange}
-        onInputChange={onInputChange}
-        options={getCategoryArray(categoriesMock)}
-        sx={{ marginBottom: '20px' }}
+        isOptionEqualToValue={(option, value) => option === value}
+        onChange={handleAutoCompleteChangeCategory}
+        onInputChange={onInputChangeCategory}
+        options={getCategoryArray(subjectsMock)}
+        sx={{ mb: '20px' }}
         textFieldProps={{
           label: t('becomeTutor.categories.mainSubjectsLabel')
         }}
-        value={searchCategory}
+        value={selectedCategory || null}
       />
       <AppSelect
-        fields={categories(searchCategory ? subjects.values : [])}
+        fields={subjectFields(
+          selectedCategory ? getCategorySubjects.subjects : []
+        )}
         label={t('becomeTutor.categories.subjectLabel')}
-        setValue={handleChangeSubject}
-        sx={{ marginBottom: '16px' }}
-        value={searchSubject}
+        setValue={handleSelectSubject}
+        sx={{ mb: '16px' }}
+        value={selectedSubject}
       />
-      <AppButton onClick={() => {}} sx={styles.button}>
+      <AppButton onClick={addCategory} sx={styles.button}>
         {t('becomeTutor.categories.btnText')}
       </AppButton>
+      <Stack direction='row' spacing={'4px'} sx={{ mt: 2, flexWrap: 'wrap' }}>
+        <AppChipList
+          defaultQuantity={subjectsChipList.length}
+          handleChipDelete={handleDelete}
+          items={subjectsChipList}
+        />
+      </Stack>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.jsx
+++ b/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.jsx
@@ -104,7 +104,7 @@ const SubjectForm = ({ handleSubmit }) => {
       </AppButton>
       <Stack direction='row' spacing={'4px'} sx={{ mt: 2, flexWrap: 'wrap' }}>
         <AppChipList
-          defaultQuantity={subjectsChipList.length}
+          defaultQuantity={3}
           handleChipDelete={handleDelete}
           items={subjectsChipList}
         />

--- a/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/subject-form/SubjectForm.styles.js
@@ -5,17 +5,14 @@ export const styles = {
     minWidth: { sm: '340px' }
   },
   button: {
-    fontWeight: 500,
-    fontSize: '16px',
-    lineHeight: '24px',
-    letterSpacing: '0.5px',
-    textTransform: 'initial',
-    backgroundColor: '#eceff1',
-    color: '#263238',
+    typography: 'button',
+    backgroundColor: 'basic.grey',
+    color: 'primary.700',
     width: '100%',
+    height: '48px',
     boxShadow: 'none',
     '&:hover': {
-      backgroundColor: '#eceff1'
+      backgroundColor: 'basic.grey'
     }
   }
 }

--- a/src/styles/app-theme/app.typography.ts
+++ b/src/styles/app-theme/app.typography.ts
@@ -55,7 +55,7 @@ const appTypography: AppTypography = {
     letterSpacing: '0.15px'
   },
   subtitle2: {
-    fontWeight: 500,
+    fontWeight: 400,
     fontSize: '14px',
     lineHeight: '20px',
     letterSpacing: '0.1px'


### PR DESCRIPTION
Added chips of selected subjects on Subjects step for a tutor stepper:

- When user selects subject and clicks on button "Add one more subject" it create a new chip with selected subject
- When user have selects 3rd or more subject it should be showed by increasing values of rest selected subjects

![image](https://github.com/user-attachments/assets/747c93ad-1d2c-4665-9388-8c0b5a713019)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted chip typography with refined letter spacing for improved text presentation.
	- Updated button appearance and subtitle styling for a modernized, consistent look.
- **New Features**
	- Enhanced the tutor subject selection form with dynamic category-based options and a convenient chip list for managing selections.
	- Improved instructional text in the tutor onboarding process to provide clearer guidance on subject selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->