### PR TITLE
Feature/73/closing confirmation pop stepper

### DIFF
--- a/src/components/popup-confirmation/ConfirmationPopUp.tsx
+++ b/src/components/popup-confirmation/ConfirmationPopUp.tsx
@@ -26,6 +26,7 @@ const ConfirmationPopUp: React.FC<ConfirmationPopUpProps> = ({
     <Dialog
       aria-describedby='alert-dialog-description'
       aria-labelledby='alert-dialog-title'
+      onClose={() => handleClickNo()}
       open={open}
     >
       <IconButton

--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { isValidElement, FC } from 'react'
 import Box from '@mui/material/Box'
 import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
@@ -19,6 +19,11 @@ interface PopupDialogProps {
   keyForm: string
 }
 
+interface PopupContentProps {
+  closeOnClickOutside?: boolean
+  closeOnIconClick?: boolean
+}
+
 const PopupDialog: FC<PopupDialogProps> = ({
   content,
   paperProps,
@@ -27,19 +32,34 @@ const PopupDialog: FC<PopupDialogProps> = ({
   keyForm
 }) => {
   const { isDirty } = useFormContext(keyForm)
-
   const [open, setOpen] = useState(false)
   const { isMobile } = useBreakpoints()
   const { closeModal } = useModalContext()
 
+  const closeOnClickOutside = isValidElement(content)
+    ? (content.props as PopupContentProps).closeOnClickOutside ?? false
+    : false
+
+  const closeOnIconClick = isValidElement(content)
+    ? (content.props as PopupContentProps).closeOnIconClick ?? false
+    : false
+
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
-  const handleClickOut = () => (isDirty ? setOpen(true) : closeModal())
-  const handleClickCloseConfirmationPopUp = () => setOpen(false)
+
+  const closeConfirmationPopUp = () => setOpen(false)
+  const openConfirmationPopUp = () => setOpen(true)
+
+  const handleClickOut = () =>
+    closeOnClickOutside && (isDirty ? openConfirmationPopUp() : closeModal())
+
   const handleClickCloseAll = () => {
-    setOpen(false)
+    closeConfirmationPopUp()
     closeModal()
   }
+
+  const handlerCloseIcon = () =>
+    closeOnIconClick ? closeModal() : openConfirmationPopUp()
 
   return (
     <Dialog
@@ -58,12 +78,12 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton onClick={closeModal} sx={styles.icon}>
+        <IconButton onClick={handlerCloseIcon} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>
         <ConfirmationPopUp
-          handleClickNo={handleClickCloseConfirmationPopUp}
+          handleClickNo={closeConfirmationPopUp}
           handleClickYes={handleClickCloseAll}
           open={open}
         />

--- a/src/components/user-steps-wrapper/UserStepsWrapper.tsx
+++ b/src/components/user-steps-wrapper/UserStepsWrapper.tsx
@@ -18,6 +18,8 @@ import { student } from '~/constants'
 
 interface UserStepsWrapperProps {
   userRole: string
+  closeOnClickOutside: boolean
+  closeOnIconClick: boolean
 }
 
 const UserStepsWrapper: FC<UserStepsWrapperProps> = ({ userRole }) => {

--- a/src/containers/guest-home-page/WhatCanYouDo.tsx
+++ b/src/containers/guest-home-page/WhatCanYouDo.tsx
@@ -39,7 +39,15 @@ const WhatCanYouDo = () => {
 
   const openSignUpDialog = useCallback(
     (actionType: string) => {
-      openModal({ component: <SignUpDialog actionType={actionType} /> })
+      openModal({
+        component: (
+          <SignUpDialog
+            actionType={actionType}
+            closeOnClickOutside
+            closeOnIconClick
+          />
+        )
+      })
       setRole(actionType)
     },
     [openModal, setRole]

--- a/src/containers/navigation-icons/guest-icons/GuestIcons.tsx
+++ b/src/containers/navigation-icons/guest-icons/GuestIcons.tsx
@@ -20,7 +20,9 @@ const GuestIcons: FC<GuestIconsProps> = ({ setSidebarOpen }) => {
   const { openModal } = useModalContext()
 
   const openLoginDialog = useCallback(() => {
-    openModal({ component: <LoginDialog /> })
+    openModal({
+      component: <LoginDialog closeOnClickOutside closeOnIconClick />
+    })
   }, [openModal])
 
   const icons = guestIcons.map(

--- a/src/pages/student-home/StudentHome.tsx
+++ b/src/pages/student-home/StudentHome.tsx
@@ -16,7 +16,13 @@ const StudentHome = () => {
   useEffect(() => {
     if (isFirstLogin) {
       openModal({
-        component: <UserStepsWrapper userRole={userRole} />,
+        component: (
+          <UserStepsWrapper
+            closeOnClickOutside={false}
+            closeOnIconClick={false}
+            userRole={userRole}
+          />
+        ),
         paperProps: {
           sx: {
             maxHeight: { sm: '652px' },

--- a/src/pages/tutor-home/TutorHome.tsx
+++ b/src/pages/tutor-home/TutorHome.tsx
@@ -17,7 +17,13 @@ const TutorHome = () => {
   useEffect(() => {
     if (isFirstLogin) {
       openModal({
-        component: <UserStepsWrapper userRole={userRole} />,
+        component: (
+          <UserStepsWrapper
+            closeOnClickOutside={false}
+            closeOnIconClick={false}
+            userRole={userRole}
+          />
+        ),
         paperProps: {
           sx: styles.modal
         }


### PR DESCRIPTION
add closing confirmation pop stepper
update closing popup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced modal dialog interactions across the app for a more intuitive experience.
	- Confirmation dialogs now automatically trigger the default negative action when closed.
	- Sign-up and login pop-ups now offer flexible closing options—users can close them by clicking outside or on dedicated icons.
	- In student and tutor views, dialog closing by external clicks is disabled to prevent unintentional closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->