### PR TITLE
Feature/252/add validation to the photo step

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -41,5 +41,8 @@ export const URLs = {
       post: '/resources-categories',
       delete: 'resources-categories'
     }
+  },
+  media: {
+    uploadImage: '/upload-image'
   }
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react'
-import axios from 'axios'
+import { useState, useEffect, useCallback } from 'react'
 
 import { Box, Typography, Alert, Snackbar, IconButton } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
@@ -53,8 +52,6 @@ const AddPhotoStep = ({ btnsBox }) => {
     const fileURL = URL.createObjectURL(file)
     setImage(fileURL)
     setImageName(file.name)
-
-    uploadImageToService(file)
   }
 
   useEffect(() => {
@@ -81,34 +78,30 @@ const AddPhotoStep = ({ btnsBox }) => {
     setIsDragged(false)
   }
 
-  const handleDragOver = (event) => {
-    event.preventDefault()
-    setIsDragged(true)
+  const handleDragOver = useCallback(
+    (event) => {
+      event.preventDefault()
+      if (!isDragged) {
+        setIsDragged(true)
+      }
 
-    console.log(isDragged)
-  }
+      console.log('This is dragOver:' + isDragged)
+    },
+    [isDragged]
+  )
 
   const handleDragLeave = (event) => {
     event.preventDefault()
-    setIsDragged(false)
-
-    console.log(isDragged)
-  }
-
-  const uploadImageToService = async (file) => {
-    try {
-      const data = new FormData()
-      data.append('image', file)
-
-      const res = await axios.post('http://localhost:8080/upload-image', data, {
-        headers: { 'Content-Type': 'multipart/form-data' }
-      })
-
-      console.log('Upload successful:', res.data)
-    } catch (error) {
-      alert('Upload failed: ' + error.message)
+    if (isDragged) {
+      setIsDragged(false)
     }
+
+    console.log('This is dragLeave:' + isDragged)
   }
+
+  useEffect(() => {
+    console.log('Final value:' + isDragged)
+  }, [isDragged])
 
   const UploadBox = () => {
     return (

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -158,7 +158,7 @@ const AddPhotoStep = ({ btnsBox }) => {
               {image ? imageName : `Upload your profile photo`}
             </Typography>
             <VisuallyHiddenInput
-              accept='image/*'
+              accept='image/png, image/jpg, image/jpeg'
               onChange={handleFileChange}
               type='file'
             />

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -44,7 +44,7 @@ const AddPhotoStep = ({ btnsBox }) => {
     }
 
     if (file.size > maxSize) {
-      setError('File size should be less than 10MB)')
+      setError('File size should be less than 10MB')
       setOpen(true)
       return
     }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -12,7 +12,6 @@ import appTypography from '~/styles/app-theme/app.typography'
 import {
   deleteImageFromCloudinary,
   uploadImageToCloudinary
-  //deleteImageFromCloudinary
 } from '~/services/cloudinary-service'
 
 const AddPhotoStep = ({ btnsBox }) => {
@@ -89,14 +88,12 @@ const AddPhotoStep = ({ btnsBox }) => {
   const handleDragOver = (event) => {
     event.preventDefault()
     setIsDragged(true)
-
     console.log(isDragged)
   }
 
   const handleDragLeave = (event) => {
     event.preventDefault()
     setIsDragged(false)
-
     console.log(isDragged)
   }
 
@@ -105,12 +102,10 @@ const AddPhotoStep = ({ btnsBox }) => {
       const data = new FormData()
       data.append('image', file)
       const res = await uploadImageToCloudinary(data)
-      console.log('Upload successful:', res.data)
       const { public_id } = res.data
-      console.log(public_id)
       setPublicId(public_id)
     } catch (error) {
-      alert('Upload failed: ' + error.message)
+      setError('Error server! Please try again later')
     }
   }
   const handleImageRemoval = async () => {

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -109,8 +109,6 @@ const AddPhotoStep = ({ btnsBox }) => {
       if (!isDragged) {
         setIsDragged(true)
       }
-
-      console.log('This is dragOver:' + isDragged)
     },
     [isDragged]
   )
@@ -120,8 +118,6 @@ const AddPhotoStep = ({ btnsBox }) => {
     if (isDragged) {
       setIsDragged(false)
     }
-
-    console.log('This is dragLeave:' + isDragged)
   }
 
   const UploadBox = () => {

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import axios from 'axios'
 
-import { Box, Typography } from '@mui/material'
-import { IconButton } from '@mui/material'
+import { Box, Typography, Alert, Snackbar, IconButton } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import CloseIcon from '@mui/icons-material/Close'
 import { styled } from '@mui/material/styles'
@@ -14,6 +14,9 @@ import appTypography from '~/styles/app-theme/app.typography'
 const AddPhotoStep = ({ btnsBox }) => {
   const [image, setImage] = useState(null)
   const [imageName, setImageName] = useState('')
+  const [error, setError] = useState(null)
+  const [open, setOpen] = useState(false)
+  const [isDragged, setIsDragged] = useState(false)
 
   const VisuallyHiddenInput = styled('input')({
     clip: 'rect(0 0 0 0)',
@@ -27,18 +30,101 @@ const AddPhotoStep = ({ btnsBox }) => {
     width: 1
   })
 
+  const addPhoto = (file) => {
+    if (!file) return
+
+    const allowedTypes = ['image/jpg', 'image/png', 'image/jpeg']
+    const maxSize = 10 * 1024 * 1024
+
+    setError(null)
+
+    if (!allowedTypes.includes(file.type)) {
+      setError('Please upload an image file(JPEG, PNG, or GIF)')
+      setOpen(true)
+      return
+    }
+
+    if (file.size > maxSize) {
+      setError('File size should be less than 10MB)')
+      setOpen(true)
+      return
+    }
+
+    const fileURL = URL.createObjectURL(file)
+    setImage(fileURL)
+    setImageName(file.name)
+
+    uploadImageToService(file)
+  }
+
+  useEffect(() => {
+    const preventDefaults = (event) => event.preventDefault()
+
+    window.addEventListener('dragover', preventDefaults)
+    window.addEventListener('drop', preventDefaults)
+
+    return () => {
+      window.removeEventListener('dragover', preventDefaults)
+      window.removeEventListener('drop', preventDefaults)
+    }
+  }, [])
+
   const handleFileChange = (event) => {
-    if (event.target.files && event.target.files[0]) {
-      const fileURL = URL.createObjectURL(event.target.files[0])
-      setImage(fileURL)
-      setImageName(event.target.files[0].name)
+    const file = event.target.files[0]
+    if (!file) return
+    addPhoto(file)
+  }
+
+  const handleDrop = (event) => {
+    event.preventDefault()
+    addPhoto(event.dataTransfer.files[0])
+    setIsDragged(false)
+  }
+
+  const handleDragOver = (event) => {
+    event.preventDefault()
+    setIsDragged(true)
+
+    console.log(isDragged)
+  }
+
+  const handleDragLeave = (event) => {
+    event.preventDefault()
+    setIsDragged(false)
+
+    console.log(isDragged)
+  }
+
+  const uploadImageToService = async (file) => {
+    try {
+      const data = new FormData()
+      data.append('image', file)
+
+      const res = await axios.post('http://localhost:8080/upload-image', data, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      })
+
+      console.log('Upload successful:', res.data)
+    } catch (error) {
+      alert('Upload failed: ' + error.message)
     }
   }
 
   const UploadBox = () => {
     return (
       <Box
-        sx={image ? { ...style.uploadBox, border: 'none' } : style.uploadBox}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        sx={
+          image
+            ? { ...style.uploadBox, border: 'none' }
+            : {
+                ...style.uploadBox,
+                borderColor: isDragged && 'success.900',
+                backgroundColor: isDragged && 'success.50'
+              }
+        }
       >
         {image ? (
           <Box sx={style.imgContainer}>
@@ -74,16 +160,12 @@ const AddPhotoStep = ({ btnsBox }) => {
             sx={style.fileUploader.button}
             variant='outlined'
           >
-            {image ? (
-              ''
-            ) : (
-              <CloudUploadIcon sx={{ mr: 1, color: 'primary.700' }} />
-            )}
-            <Typography>
+            {!image && <CloudUploadIcon sx={{ mr: 1, color: 'primary.700' }} />}
+            <Typography sx={{ textOverflow: 'clip' }}>
               {image ? imageName : `Upload your profile photo`}
             </Typography>
             <VisuallyHiddenInput
-              multiple
+              accept='image/*'
               onChange={handleFileChange}
               type='file'
             />
@@ -105,6 +187,17 @@ const AddPhotoStep = ({ btnsBox }) => {
 
   return (
     <Box sx={style.root}>
+      <Snackbar
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        autoHideDuration={5000}
+        onClose={() => setOpen(false)}
+        open={open}
+      >
+        <Alert onClose={() => setOpen(false)} severity='error'>
+          {error}
+        </Alert>
+      </Snackbar>
+
       <FileUploaderBox />
       <UploadBox />
       <Box sx={{ gridArea: 'empty', visibility: 'hidden' }} />

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
-import { Box, Typography } from '@mui/material'
-import { IconButton } from '@mui/material'
+import { Box, Typography, Alert, Snackbar, IconButton } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import CloseIcon from '@mui/icons-material/Close'
 import { styled } from '@mui/material/styles'
@@ -10,10 +9,19 @@ import AppButton from '~/components/app-button/AppButton'
 
 import { style } from '~/containers/tutor-home-page/add-photo-step/AddPhotoStep.style'
 import appTypography from '~/styles/app-theme/app.typography'
+import {
+  deleteImageFromCloudinary,
+  uploadImageToCloudinary
+  //deleteImageFromCloudinary
+} from '~/services/cloudinary-service'
 
 const AddPhotoStep = ({ btnsBox }) => {
   const [image, setImage] = useState(null)
   const [imageName, setImageName] = useState('')
+  const [error, setError] = useState(null)
+  const [open, setOpen] = useState(false)
+  const [isDragged, setIsDragged] = useState(false)
+  const [publicId, setPublicId] = useState(null)
 
   const VisuallyHiddenInput = styled('input')({
     clip: 'rect(0 0 0 0)',
@@ -27,18 +35,104 @@ const AddPhotoStep = ({ btnsBox }) => {
     width: 1
   })
 
-  const handleFileChange = (event) => {
-    if (event.target.files && event.target.files[0]) {
-      const fileURL = URL.createObjectURL(event.target.files[0])
-      setImage(fileURL)
-      setImageName(event.target.files[0].name)
+  const addPhoto = (file) => {
+    if (!file) return
+
+    const allowedTypes = ['image/jpg', 'image/png', 'image/jpeg']
+    const maxSize = 10 * 1024 * 1024
+
+    setError(null)
+
+    if (!allowedTypes.includes(file.type)) {
+      setError('Please upload an image file(JPEG, PNG, or GIF)')
+      setOpen(true)
+      return
     }
+
+    if (file.size > maxSize) {
+      setError('File size should be less than 10MB)')
+      setOpen(true)
+      return
+    }
+
+    const fileURL = URL.createObjectURL(file)
+    setImage(fileURL)
+    setImageName(file.name)
+
+    uploadImageToService(file)
+  }
+
+  useEffect(() => {
+    const preventDefaults = (event) => event.preventDefault()
+
+    window.addEventListener('dragover', preventDefaults)
+    window.addEventListener('drop', preventDefaults)
+
+    return () => {
+      window.removeEventListener('dragover', preventDefaults)
+      window.removeEventListener('drop', preventDefaults)
+    }
+  }, [])
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0]
+    if (!file) return
+    addPhoto(file)
+  }
+
+  const handleDrop = (event) => {
+    event.preventDefault()
+    addPhoto(event.dataTransfer.files[0])
+    setIsDragged(false)
+  }
+
+  const handleDragOver = (event) => {
+    event.preventDefault()
+    setIsDragged(true)
+
+    console.log(isDragged)
+  }
+
+  const handleDragLeave = (event) => {
+    event.preventDefault()
+    setIsDragged(false)
+
+    console.log(isDragged)
+  }
+
+  const uploadImageToService = async (file) => {
+    try {
+      const data = new FormData()
+      data.append('image', file)
+      const res = await uploadImageToCloudinary(data)
+      console.log('Upload successful:', res.data)
+      const { public_id } = res.data
+      console.log(public_id)
+      setPublicId(public_id)
+    } catch (error) {
+      alert('Upload failed: ' + error.message)
+    }
+  }
+  const handleImageRemoval = async () => {
+    deleteImageFromCloudinary(publicId)
+    setImage(null)
   }
 
   const UploadBox = () => {
     return (
       <Box
-        sx={image ? { ...style.uploadBox, border: 'none' } : style.uploadBox}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        sx={
+          image
+            ? { ...style.uploadBox, border: 'none' }
+            : {
+                ...style.uploadBox,
+                borderColor: isDragged && 'success.900',
+                backgroundColor: isDragged && 'success.50'
+              }
+        }
       >
         {image ? (
           <Box sx={style.imgContainer}>
@@ -74,23 +168,20 @@ const AddPhotoStep = ({ btnsBox }) => {
             sx={style.fileUploader.button}
             variant='outlined'
           >
-            {image ? (
-              ''
-            ) : (
-              <CloudUploadIcon sx={{ mr: 1, color: 'primary.700' }} />
-            )}
-            <Typography>
+            {!image && <CloudUploadIcon sx={{ mr: 1, color: 'primary.700' }} />}
+            <Typography sx={{ textOverflow: 'clip' }}>
               {image ? imageName : `Upload your profile photo`}
             </Typography>
             <VisuallyHiddenInput
-              multiple
+              accept='image/*'
+              name='image'
               onChange={handleFileChange}
               type='file'
             />
             {!image ? (
               ''
             ) : (
-              <IconButton aria-label='close' onClick={() => setImage(null)}>
+              <IconButton aria-label='close' onClick={handleImageRemoval}>
                 <CloseIcon />
               </IconButton>
             )}
@@ -105,6 +196,17 @@ const AddPhotoStep = ({ btnsBox }) => {
 
   return (
     <Box sx={style.root}>
+      <Snackbar
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        autoHideDuration={5000}
+        onClose={() => setOpen(false)}
+        open={open}
+      >
+        <Alert onClose={() => setOpen(false)} severity='error'>
+          {error}
+        </Alert>
+      </Snackbar>
+
       <FileUploaderBox />
       <UploadBox />
       <Box sx={{ gridArea: 'empty', visibility: 'hidden' }} />

--- a/src/services/cloudinary-service.ts
+++ b/src/services/cloudinary-service.ts
@@ -1,0 +1,19 @@
+import { axiosClient } from '~/plugins/axiosClient'
+import { AxiosResponse } from 'axios'
+import { createUrlPath } from '~/utils/helper-functions'
+import { URLs } from '~/constants/request'
+
+export const cloudinaryService = {
+  uploadImageToCloudinary: (file: FormData): Promise<AxiosResponse> => {
+    return axiosClient.post(URLs.media.uploadImage, file, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  },
+  deleteImageFromCloudinary: (publicId: string): Promise<AxiosResponse> => {
+    const deleteUrl = createUrlPath(URLs.media.uploadImage, publicId)
+    console.log(deleteUrl)
+    return axiosClient.delete(deleteUrl)
+  }
+}
+export const { uploadImageToCloudinary, deleteImageFromCloudinary } =
+  cloudinaryService


### PR DESCRIPTION
Added validation to the add-photo-step component. Only images of types: .jpeg, .jpg, .png, are allowed. Maximum size of the image is 10MB. If the requirements are not met then the alert MUI component pops up.

Implemented the drag-and-drop functionality. The uploadBox changes it's style when a file is hovering above. Default behaviour of the file event listeners is prevented. The file will no longer be opened in a new tab by browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image upload experience with improved state management and error handling.
	- Introduced drag-and-drop functionality for file uploads.
	- Added file validations for JPEG/PNG formats and a maximum size limit of 10 MB.
	- Improved user feedback with Snackbar notifications for upload errors.
	- Updated visual indicators for file drag-and-drop interactions.
	- Integrated new service for uploading and deleting images from Cloudinary.
	- Added a dedicated endpoint for image uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->